### PR TITLE
Fix for over-frequent tick timer callbacks

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,8 @@ static WeatherLayer *weather_layer;
 static char date_text[] = "XXX 00";
 static char time_text[] = "00:00";
 
+bool timer_tick_each_second = true;
+
 /* Preload the fonts */
 GFont font_date;
 GFont font_time;
@@ -68,6 +70,11 @@ static void handle_tick(struct tm *tick_time, TimeUnits units_changed)
     animation_step = (animation_step + 1) % 3;
   }
   else {
+    if (timer_tick_each_second) {
+      timer_tick_each_second = false;
+      tick_timer_service_unsubscribe();
+      tick_timer_service_subscribe(MINUTE_UNIT, handle_tick);
+    }
     // Update the weather icon and temperature
     if (weather_data->error) {
       weather_layer_set_icon(weather_layer, WEATHER_ICON_PHONE_ERROR);

--- a/src/main.c
+++ b/src/main.c
@@ -72,8 +72,8 @@ static void handle_tick(struct tm *tick_time, TimeUnits units_changed)
   else {
     if (timer_tick_each_second) {
       timer_tick_each_second = false;
-      tick_timer_service_unsubscribe();
-      tick_timer_service_subscribe(MINUTE_UNIT, handle_tick);
+      //tick_timer_service_unsubscribe();
+      //tick_timer_service_subscribe(MINUTE_UNIT, handle_tick);
     }
     // Update the weather icon and temperature
     if (weather_data->error) {


### PR DESCRIPTION
Right now the watchface subscribes to the tick timer at `SECOND_UNIT` granularity and leaves it at that. Given that (beyond the initial loading animation), the watchface is only updated every minute, this seems unnecessary. I'm not sure quite how much of a battery drain this is, but better to err on the side of caution, I suppose.

Anyway, all this does is unsubscribe from the second-timer once the loading animation has completed and changes it to a minute-timer.

The only possible caveat: when `request_weather()` is called after 15 minutes, the display won't be updated with the new weather data until the _next_ timer tick, 60s later. If this is a real concern, it'd be possible to set the timer back to 1s refreshing while the weather data is being loaded, but I figured this would introduce unnecessary extra logic (and an opportunity for me to bug something out)...
